### PR TITLE
validation checks (1&2); ensuring scripts run

### DIFF
--- a/scripts/01-download-dataset.R
+++ b/scripts/01-download-dataset.R
@@ -1,4 +1,3 @@
-# library(pkg.drugage)
 pak::pak("DSCI-310-2025/pkg.drugage")
 library(pkg.drugage)
 

--- a/scripts/01-download-dataset.R
+++ b/scripts/01-download-dataset.R
@@ -1,5 +1,6 @@
 # library(pkg.drugage)
 pak::pak("DSCI-310-2025/pkg.drugage")
+library(pkg.drugage)
 
 url <- "https://raw.githubusercontent.com/rudeboybert/fivethirtyeight/refs/heads/master/data-raw/drug-use-by-age/drug-use-by-age.csv"
 destination <- "data/raw/"

--- a/scripts/02-data-clean-transform.R
+++ b/scripts/02-data-clean-transform.R
@@ -1,4 +1,5 @@
 pak::pak("DSCI-310-2025/pkg.drugage")
+library(pkg.drugage)
 library(docopt)
 
 "This script cleans and saves drug use data

--- a/scripts/02-data-clean-transform.R
+++ b/scripts/02-data-clean-transform.R
@@ -1,4 +1,3 @@
-pak::pak("DSCI-310-2025/pkg.drugage")
 library(pkg.drugage)
 library(docopt)
 

--- a/scripts/02.5-data-validation.R
+++ b/scripts/02.5-data-validation.R
@@ -4,7 +4,23 @@ library(dplyr)
 data_transformed <- read.csv("data/clean/data-cleaned.csv")
 str(data_transformed)
 
-# VALIDATION - Check that row data is not duplicated
+# VALIDATION - Correct data file format ------------------
+create_agent(tbl = data_transformed, tbl_name = "fileFormat-checks") %>%
+  col_is_numeric(columns = vars(
+    alcohol.use, marijuana.use, heroin.frequency, marijuana.frequency
+  )) %>%
+  col_is_character(columns = vars(age, class)) %>%
+  interrogate()
+
+# VALIDATION - Correct column names ------------------
+create_agent(tbl = data_transformed, tbl_name = "colName-checks") %>%
+  col_exists(columns = c(
+    "alcohol.use", "marijuana.use", "cocaine.use", "cocaine.frequency",
+    "heroin.use", "heroin.frequency", "marijuana.frequency"
+  )) %>%
+  interrogate()
+
+# VALIDATION - Check that row data is not duplicated ------------------
 create_agent(tbl = data_transformed, tbl_name = "duplicate-check") %>%
   rows_distinct() %>%
   col_vals_unique(
@@ -14,7 +30,7 @@ create_agent(tbl = data_transformed, tbl_name = "duplicate-check") %>%
   interrogate()
 
 
-# VALIDATION - Check that there are no anomalous or outlier values
+# VALIDATION - Check that there are no anomalous or outlier values ------------------
 # Function to calculate IQR thresholds
 get_iqr_bounds <- function(column_data) {
   Q1 <- quantile(column_data, 0.25, na.rm = TRUE)
@@ -39,7 +55,7 @@ create_agent(tbl = data_transformed, tbl_name = "outlier-check") %>%
   interrogate()
 
 
-# VALIDATION - Correct category levels (i.e., no string mismatches or single values)
+# VALIDATION - Correct category levels (i.e., no string mismatches or single values) ------------------
 valid_age_levels <- c("12", "13", "14", "15", "16", "17", "18", "19",
                       "20", "21", "22-23", "24-25", "26-29", "30-34",
                       "35-49", "50-64", "65+")
@@ -61,7 +77,7 @@ create_agent(tbl = data_transformed, tbl_name = "category-checks") %>%
   interrogate()
 
 
-#VALIDATION - Target/response variable follows expected distribution
+#VALIDATION - Target/response variable follows expected distribution ------------------
 create_agent(tbl = data_transformed, tbl_name = "target_class_check") %>%
   # Ensure class is either "youth" or "adult"
   col_vals_in_set(

--- a/scripts/03-eda.R
+++ b/scripts/03-eda.R
@@ -1,8 +1,8 @@
 library(dplyr)
 library(tidyr)
 library(docopt)
-# library(pkg.drugage)
 pak::pak("DSCI-310-2025/pkg.drugage")
+library(pkg.drugage)
 
 "This script performs some exploratory data analysis on the cleaned and transformed drug use data
 

--- a/scripts/03-eda.R
+++ b/scripts/03-eda.R
@@ -1,7 +1,6 @@
 library(dplyr)
 library(tidyr)
 library(docopt)
-pak::pak("DSCI-310-2025/pkg.drugage")
 library(pkg.drugage)
 
 "This script performs some exploratory data analysis on the cleaned and transformed drug use data

--- a/scripts/04-analysis.R
+++ b/scripts/04-analysis.R
@@ -14,7 +14,6 @@ library(workflows)
 library(dplyr)
 library(rsample)
 library(readr)
-pak::pak("DSCI-310-2025/pkg.drugage")
 library(pkg.drugage)
 
 # Parse command-line arguments

--- a/scripts/04-analysis.R
+++ b/scripts/04-analysis.R
@@ -14,8 +14,8 @@ library(workflows)
 library(dplyr)
 library(rsample)
 library(readr)
-# library(pkg.drugage)
 pak::pak("DSCI-310-2025/pkg.drugage")
+library(pkg.drugage)
 
 # Parse command-line arguments
 opt <- docopt(doc)


### PR DESCRIPTION
summary of tasks:
- used `pak::pak("DSCI-310-2025/pkg.drugage")` and `library(pkg.drugage)` in all scripts, which may be redundant. Please suggest a change if there is a better way.
- renamed `...data-validation` to `...data-validation.R` so makefile can recognize the file
- added my checks for #169 
- updated `...validation.R` file so each check heading is pronounced